### PR TITLE
Potential fix for code scanning alert no. 1: Disabled Spring CSRF protection

### DIFF
--- a/source/did-verifier-server/src/main/java/org/omnione/did/base/config/SecurityConfig.java
+++ b/source/did-verifier-server/src/main/java/org/omnione/did/base/config/SecurityConfig.java
@@ -53,7 +53,6 @@ public class SecurityConfig {
             throws Exception {
 
         return httpSecurity
-                .csrf(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .logout(AbstractHttpConfigurer::disable)


### PR DESCRIPTION
Potential fix for [https://github.com/poohslaOrg/did-verifier-server/security/code-scanning/1](https://github.com/poohslaOrg/did-verifier-server/security/code-scanning/1)

To fix the problem, we need to enable CSRF protection in the `securityFilterChain` method. This involves removing the line that disables CSRF protection and allowing Spring Security to handle CSRF protection by default. This change ensures that the application is protected against CSRF attacks without altering any other existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
